### PR TITLE
Allow a more flexible Content-type.

### DIFF
--- a/lib/payload-parser.js
+++ b/lib/payload-parser.js
@@ -14,7 +14,12 @@ module.exports = function parseSiprecPayload(opts) {
   return new Promise((resolve, reject) => {
     let sdp, meta ;
     for (let i = 0; i < req.payload.length; i++) {
-      switch (req.payload[i].type) {
+      let content_type = req.payload[i].type;
+      if (!content_type) {
+        continue;
+      }
+      content_type = content_type.split(';')[0];
+      switch (content_type) {
         case 'application/sdp':
           sdp = req.payload[i].content ;
           break ;


### PR DESCRIPTION
Some SBCs (such as Dialpad) seem to include a more verbose `Content-type` in the SDP body of the SIP INVITE, such as `Content-Type: application/sdp;charset=ISO-10646`. This PR adds more flexible parsing behavior for these sorts of headers.