### PR TITLE
Avoid double trailing CRLF in SDP

### DIFF
--- a/lib/payload-parser.js
+++ b/lib/payload-parser.js
@@ -59,7 +59,7 @@ module.exports = function parseSiprecPayload(opts) {
       }
       let new_sdp1 = "";
       if (codec_payload != "unknown") {
-        sdp1_lines = (opts.sdp1).split("\r\n");
+        sdp1_lines = opts.sdp1.trimEnd().split("\r\n");
         for (part in sdp1_lines) {
           if ( sdp1_lines[part].startsWith("m=audio") ){
             let words = sdp1_lines[part].split(' ');


### PR DESCRIPTION
rtpengine fails if the SDP has an empty line.